### PR TITLE
Add dark mode with light/dark toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-error.log*
 # cached notion images (keep directory structure but ignore cached files)
 public/images/notion/*
 !public/images/notion/.gitkeep
+.env*.local

--- a/components/ThemeToggle.js
+++ b/components/ThemeToggle.js
@@ -1,0 +1,27 @@
+import { Sun, Moon } from 'feather-icons-react';
+import { useTheme } from '../context/ThemeContext';
+
+export default function ThemeToggle() {
+  const { theme, setTheme, mounted } = useTheme();
+
+  const toggleTheme = () => {
+    setTheme(theme === 'light' ? 'dark' : 'light');
+  };
+
+  // Render placeholder during SSR to prevent hydration mismatch
+  if (!mounted) {
+    return <div className="w-5 h-5" />;
+  }
+
+  const Icon = theme === 'light' ? Sun : Moon;
+
+  return (
+    <button
+      onClick={toggleTheme}
+      aria-label={`Current theme: ${theme}. Click to change.`}
+      className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 hover:cursor-pointer"
+    >
+      <Icon className="h-5 w-5" />
+    </button>
+  );
+}

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Home, Linkedin, Instagram } from "feather-icons-react";
+import ThemeToggle from "./ThemeToggle";
 
 const NavBar = () => {
   return (
@@ -16,22 +17,24 @@ const NavBar = () => {
           <div className="">
             <div className="ml-4 flex items-center md:ml-auto space-x-2">
               <a href="/">
-                <Home className="text-gray-400 hover:text-gray-600 hover:cursor-pointer h-5 w-5" />
+                <Home className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 hover:cursor-pointer h-5 w-5" />
               </a>
               <a
                 href="https://www.linkedin.com/in/jasonscui/"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <Linkedin className="text-gray-400 hover:text-gray-600 hover:cursor-pointer h-5 w-5" />
+                <Linkedin className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 hover:cursor-pointer h-5 w-5" />
               </a>
               <a
                 href="https://www.instagram.com/jasonscui/"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <Instagram className="text-gray-400 hover:text-gray-600 hover:cursor-pointer h-5 w-5" />
+                <Instagram className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 hover:cursor-pointer h-5 w-5" />
               </a>
+              <span className="border-l border-gray-300 dark:border-gray-600 h-5" />
+              <ThemeToggle />
             </div>
           </div>
         </div>

--- a/context/ThemeContext.js
+++ b/context/ThemeContext.js
@@ -1,0 +1,47 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+const ThemeContext = createContext(undefined);
+
+function getInitialTheme() {
+  if (typeof window === 'undefined') return 'light';
+  const stored = localStorage.getItem('theme');
+  if (stored === 'light' || stored === 'dark') return stored;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export function ThemeProvider({ children }) {
+  const [theme, setThemeState] = useState('light');
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setThemeState(getInitialTheme());
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [theme]);
+
+  const setTheme = (newTheme) => {
+    setThemeState(newTheme);
+    localStorage.setItem('theme', newTheme);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, mounted }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/pages/[id].js
+++ b/pages/[id].js
@@ -143,7 +143,7 @@ const renderBlock = (block) => {
             style={width && height ? { aspectRatio: `${width}/${height}` } : {}}
           />
           {caption && (
-            <figcaption className="mt-2 text-sm text-gray-600 italic text-center">
+            <figcaption className="mt-2 text-sm text-gray-600 dark:text-gray-400 italic text-center">
               {caption}
             </figcaption>
           )}
@@ -153,7 +153,7 @@ const renderBlock = (block) => {
       return <hr key={id} />;
     case "quote":
       return (
-        <div class="bg-gray-100 border-l-4 border-gray-500 text-gray-700 p-4 my-4 rounded italic">
+        <div className="bg-gray-100 border-l-4 border-gray-500 text-gray-700 dark:bg-neutral-800 dark:border-neutral-500 dark:text-neutral-300 p-4 my-4 rounded italic">
           <blockquote key={id}>{value.rich_text[0].plain_text}</blockquote>
         </div>
       );
@@ -241,7 +241,7 @@ export default function Post({ page, blocks }) {
           <div className="mb-12">
             {status === "Draft" ? (
               <div
-                className="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4"
+                className="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 dark:bg-yellow-900/30 dark:border-yellow-600 dark:text-yellow-300 p-4"
                 role="alert"
               >
                 <p className="font-bold">Draft</p>
@@ -253,7 +253,7 @@ export default function Post({ page, blocks }) {
             <h1 className="font-extrabold text-3xl mt-4 mb-4">
               <Text text={page.properties.Name.title} />
             </h1>
-            <div className="font-mono text-neutral-500 tracking-tighter">
+            <div className="font-mono text-neutral-500 dark:text-neutral-400 tracking-tighter">
               {formattedDate}
             </div>
           </div>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,12 +1,15 @@
 import "../styles/globals.css";
 import { Analytics } from "@vercel/analytics/react";
+import { ThemeProvider } from "../context/ThemeContext";
 
 function MyApp({ Component, pageProps }) {
   return (
-    <main>
-      <Component {...pageProps} />
-      <Analytics />
-    </main>
+    <ThemeProvider>
+      <main>
+        <Component {...pageProps} />
+        <Analytics />
+      </main>
+    </ThemeProvider>
   );
 }
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,29 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head />
+      <body>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                try {
+                  var theme = localStorage.getItem('theme');
+                  var isDark = theme === 'dark' ||
+                    (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches);
+                  if (isDark) {
+                    document.documentElement.classList.add('dark');
+                  }
+                } catch (e) {}
+              })();
+            `,
+          }}
+        />
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -69,13 +69,13 @@ export default function Home({ posts }) {
                       post.properties?.Slug?.rich_text[0]?.text?.content ||
                       post.id
                     }`}
-                    className="text-black"
+                    className="text-black dark:text-white"
                   >
                     <h3 className="mb-1">
                       {post.properties.Name.title[0].plain_text}
                     </h3>
 
-                    <div className="font-mono text-sm text-neutral-500 tracking-tighter">
+                    <div className="font-mono text-sm text-neutral-500 dark:text-neutral-400 tracking-tighter">
                       {date}
                     </div>
                   </Link>

--- a/pages/index.module.css
+++ b/pages/index.module.css
@@ -34,10 +34,8 @@
   letter-spacing: 0.5px;
 }
 
-@media (prefers-color-scheme: dark) {
-  .heading {
-    border-color: #343539;
-  }
+:global(.dark) .heading {
+  border-color: #343539;
 }
 
 .posts {

--- a/pages/investing.js
+++ b/pages/investing.js
@@ -118,15 +118,15 @@ export default function Investing() {
             
             <div className="space-y-6">
               {investments.map((investment) => (
-                <div key={investment.name} className="border-l-2 border-gray-200 pl-4 hover:border-gray-400 transition-colors">
+                <div key={investment.name} className="border-l-2 border-gray-200 dark:border-neutral-700 pl-4 hover:border-gray-400 dark:hover:border-neutral-500 transition-colors">
                   <div className="flex items-baseline justify-between">
                     <h3 className="font-semibold text-lg">{investment.name}</h3>
-                    <span className="font-mono text-sm text-neutral-500 tracking-tighter">
+                    <span className="font-mono text-sm text-neutral-500 dark:text-neutral-400 tracking-tighter">
                       {investment.year}
                     </span>
                   </div>
-                  <p className="text-gray-600 mt-1">{investment.description}</p>
-                  <span className="inline-block mt-2 text-xs font-mono uppercase tracking-wider text-gray-500 bg-gray-100 px-2 py-1 rounded">
+                  <p className="text-gray-600 dark:text-gray-400 mt-1">{investment.description}</p>
+                  <span className="inline-block mt-2 text-xs font-mono uppercase tracking-wider text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-neutral-800 px-2 py-1 rounded">
                     {investment.category}
                   </span>
                 </div>

--- a/pages/post.module.css
+++ b/pages/post.module.css
@@ -95,16 +95,18 @@
   margin-bottom: 10px;
 }
 
-@media (prefers-color-scheme: dark) {
-  .code {
-    background-color: rgb(15, 8, 28);
-  }
-  .file:hover {
-    background: rgba(255, 255, 255, 0.1);
-    cursor: pointer;
-    border-radius: 2px;
-  }
-  .pre {
-    background-color: rgb(15, 8, 28);
-  }
+:global(.dark) .code {
+  background-color: rgb(45, 45, 45);
+  color: rgb(230, 230, 230);
+}
+
+:global(.dark) .file:hover {
+  background: rgba(255, 255, 255, 0.1);
+  cursor: pointer;
+  border-radius: 2px;
+}
+
+:global(.dark) .pre {
+  background-color: rgb(30, 30, 30);
+  color: rgb(220, 220, 220);
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,12 +2,26 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  body {
+    @apply bg-white text-black dark:bg-neutral-900 dark:text-neutral-100;
+  }
+
+  hr {
+    @apply border-gray-200 dark:border-neutral-700;
+  }
+}
+
 p > a {
   text-decoration: underline;
   font-weight: 500;
   text-decoration-color: #a3a3a3;
   text-decoration-thickness: 0.1em;
   text-underline-offset: 2px;
+}
+
+.dark p > a {
+  text-decoration-color: #525252;
 }
 
 span > a {
@@ -18,6 +32,11 @@ span > a {
   text-underline-offset: 2px;
 }
 
+.dark span > a {
+  text-decoration-color: #525252;
+}
+
 * {
   box-sizing: border-box;
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,9 @@ module.exports = {
   content: [
     "./pages/**/*.{js,ts,jsx,tsx}",
     "./components/**/*.{js,ts,jsx,tsx}",
+    "./context/**/*.{js,ts,jsx,tsx}",
   ],
+  darkMode: 'class',
   theme: {
     extend: {},
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,10 +180,10 @@
   dependencies:
     glob "7.1.7"
 
-"@next/swc-darwin-arm64@13.4.4":
+"@next/swc-darwin-x64@13.4.4":
   version "13.4.4"
-  resolved "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.4.tgz"
-  integrity sha512-xfjgXvp4KalNUKZMHmsFxr1Ug+aGmmO6NWP0uoh4G3WFqP/mJ1xxfww0gMOeMeSq/Jyr5k7DvoZ2Pv+XOITTtw==
+  resolved "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.4.tgz"
+  integrity sha512-ZY9Ti1hkIwJsxGus3nlubIkvYyB0gNOYxKrfsOrLEqD0I2iCX8D7w8v6QQZ2H+dDl6UT29oeEUdDUNGk4UEpfg==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1163,10 +1163,10 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-esbuild-darwin-arm64@0.14.47:
+esbuild-darwin-64@0.14.47:
   version "0.14.47"
-  resolved "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.47.tgz"
-  integrity sha512-seCmearlQyvdvM/noz1L9+qblC5vcBrhUaOoLEDDoLInF/VQ9IkobGiLlyTPYP5dW1YD4LXhtBgOyevoIHGGnw==
+  resolved "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.47.tgz"
+  integrity sha512-R6oaW0y5/u6Eccti/TS6c/2c1xYTb1izwK3gajJwi4vIfNs1s8B1dQzI1UiC9T61YovOQVuePDcfqHLT3mUZJA==
 
 esbuild@0.14.47:
   version "0.14.47"


### PR DESCRIPTION
## Summary
- Add class-based dark mode using Tailwind's `darkMode: 'class'` with a ThemeContext provider and two-state (light/dark) toggle
- Theme toggle shows Sun/Moon icons in the navbar, separated from social icons by a vertical divider
- Dark styles for all pages and components: code blocks, quotes, draft banners, post dates, investments, links
- Smooth 300ms CSS transitions on background-color, color, and border-color
- Blocking script in `_document.js` prevents flash of unstyled content (FOUC) on page load
- Persists preference to localStorage, falls back to OS preference on first visit

## Test plan
- [ ] Toggle switches between Sun (light) and Moon (dark) icons
- [ ] First visit with no localStorage matches OS preference
- [ ] Preference persists across page reloads
- [ ] No flash of wrong theme on load
- [ ] Code blocks, quotes, and draft banners render correctly in both themes
- [ ] Transitions animate smoothly between themes
- [ ] Theme toggle is visually separated from social icons by a divider

🤖 Generated with [Claude Code](https://claude.com/claude-code)