### PR TITLE
Add dark mode with light/dark toggle

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -38,5 +38,8 @@ span > a {
 
 * {
   box-sizing: border-box;
-  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
+body {
+  transition: background-color 0.3s ease, color 0.3s ease;
 }


### PR DESCRIPTION
## Summary
- Add dark mode support with a two-state light/dark toggle in the navbar
- Persist theme preference in localStorage with system preference detection
- Scope transition to `body` only for smooth, lag-free toggling on mobile

## Test plan
- [ ] Toggle light/dark on desktop and mobile — background and text transition together smoothly
- [ ] Refresh page — theme preference persists
- [ ] Check all page types (index, blog post, investing) render correctly in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)